### PR TITLE
Make image use META_SITE_PROTOCOL instead of default 'http'

### DIFF
--- a/meta_mixin/models.py
+++ b/meta_mixin/models.py
@@ -2,6 +2,7 @@
 from copy import copy
 
 from django.contrib.sites.models import Site
+from meta.settings import SITE_PROTOCOL
 
 from . import settings
 
@@ -106,12 +107,17 @@ class ModelMeta(object):
             return ''
 
     def get_meta_protocol(self):
-        return settings.META_SITE_PROTOCOL
+        return SITE_PROTOCOL
 
     def make_full_url(self, url):
         s = Site.objects.get_current()
         meta_protocol = self.get_meta_protocol()
+        if url.startswith('http'):
+            return url
         if s.domain.find('http') > -1:
             return "%s%s" % (s.domain, url)  # pragma: no cover
         else:
-            return "%s://%s%s" % (meta_protocol, s.domain, url)
+            if url.startswith('/'):
+                return "%s://%s%s" % (meta_protocol, s.domain, url)
+            else:
+                return "%s://%s/%s" % (meta_protocol, s.domain, url)

--- a/meta_mixin/models.py
+++ b/meta_mixin/models.py
@@ -105,9 +105,13 @@ class ModelMeta(object):
         except AttributeError:  # pragma: no cover
             return ''
 
+    def get_meta_protocol(self):
+        return settings.META_SITE_PROTOCOL
+
     def make_full_url(self, url):
         s = Site.objects.get_current()
+        meta_protocol = self.get_meta_protocol()
         if s.domain.find('http') > -1:
             return "%s%s" % (s.domain, url)  # pragma: no cover
         else:
-            return "http://%s%s" % (s.domain, url)
+            return "%s://%s%s" % (meta_protocol, s.domain, url)

--- a/tests/test_mixin.py
+++ b/tests/test_mixin.py
@@ -30,6 +30,7 @@ class TestMeta_(TestCase):
             main_image='/path/to/image'
         )
 
+    @override_settings(META_SITE_PROTOCOL='http')
     def test_as_meta(self):
         expected = {
             'locale': 'dummy_locale',
@@ -106,3 +107,8 @@ class TestMeta_(TestCase):
             googleplus_scope('bar'),
             ' itemscope itemtype="http://schema.org/bar" '
         )
+
+    @override_settings(META_SITE_PROTOCOL='https')
+    def test_image_protocol(self):
+        meta = self.post.as_meta()
+        self.assertEqual('https://example.com/path/to/image', getattr(meta, 'image'))

--- a/tests/test_mixin.py
+++ b/tests/test_mixin.py
@@ -110,5 +110,7 @@ class TestMeta_(TestCase):
 
     @override_settings(META_SITE_PROTOCOL='https')
     def test_image_protocol(self):
+        from meta import settings
+        settings.SITE_PROTOCOL = 'https'
         meta = self.post.as_meta()
         self.assertEqual('https://example.com/path/to/image', getattr(meta, 'image'))


### PR DESCRIPTION
The method `make_full_url` would always use 'http', ignoring `META_SITE_PROTOCOL` setting. It should probably use it, versus default 'http'.